### PR TITLE
Pfade/Links & Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Willkommen bei NADOO-IT
-| [Christoph Backhaus IT](https://wirrettendeinezeit.de) | **Unser Team** | **Unsere Mission** | **Unsere Kernwerte** |
-|:--- | :--- | :--- | :--- |
-| ![NADOO-IT](images/nadooit.png) |  ... | - **Entwicklung einer Plattform von Anwendungsentwickler:innen für Anwendungsentwickler:innen** |  - **Es gibt keine Fehler, sondern ausschließlich Chancen, sich gemeinsam weiter zu entwickeln!** |
-| 🏣 Anschrift | Am Markt 1, 47229 Duisburg | - Vorbereitung für Unternehmensarbeit und Selbständigkeit | - **Es gibt keine dummen Fragen!** |
-| 📞 Telefon | +49 2065 7098429 | - Programmieren & Teamarbeit |- **nur gemeinsam/zusammen sind wir stark!** |
-| 📱 Mobil | +49 176 565 44 075 | - Ermöglichung von Wegen aus dem Hamsterrad | |
-| 📧 E-Mail | <christoph.backhaus@nadooit.de> | - Etablierung von Standort-unbhängigen Möglichkeiten zur Zusammenarbeit | |
-| Discord | [NADOO-IT]( https://discord.gg/Ffv4JTFE7E) | - Ermöglichung von work-life-balance für alle | -Vereinbarkeit von Job & Familie |
-| Twitch | [NADOO-IT](https://www.twitch.tv/nadooit_christophba) | | |
+
+| [Christoph Backhaus IT](https://wirrettendeinezeit.de) | **Unser Team**                                        | **Unsere Mission**                                                                              | **Unsere Kernwerte**                                                                             |
+| :----------------------------------------------------- | :---------------------------------------------------- | :---------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
+| ![NADOO-IT](images/nadooit.png)                        | ...                                                   | - **Entwicklung einer Plattform von Anwendungsentwickler:innen für Anwendungsentwickler:innen** | - **Es gibt keine Fehler, sondern ausschließlich Chancen, sich gemeinsam weiter zu entwickeln!** |
+| 🏣 Anschrift                                           | Am Markt 1, 47229 Duisburg                            | - Vorbereitung für Unternehmensarbeit und Selbständigkeit                                       | - **Es gibt keine dummen Fragen!**                                                               |
+| 📞 Telefon                                             | +49 2065 7098429                                      | - Programmieren & Teamarbeit                                                                    | - **nur gemeinsam/zusammen sind wir stark!**                                                     |
+| 📱 Mobil                                               | +49 176 565 44 075                                    | - Ermöglichung von Wegen aus dem Hamsterrad                                                     |                                                                                                  |
+| 📧 E-Mail                                              | <christoph.backhaus@nadooit.de>                       | - Etablierung von Standort-unbhängigen Möglichkeiten zur Zusammenarbeit                         |                                                                                                  |
+| Discord                                                | [NADOO-IT](https://discord.gg/Ffv4JTFE7E)             | - Ermöglichung von work-life-balance für alle                                                   | -Vereinbarkeit von Job & Familie                                                                 |
+| Twitch                                                 | [NADOO-IT](https://www.twitch.tv/nadooit_christophba) |                                                                                                 |                                                                                                  |
 
 ---
 
@@ -17,7 +18,7 @@ Herzlich willkommen zu deinem Einstieg in deine IT-Karriere bei uns!
 
 - Das "#globalyou" oder auch "#gerneperdu" ist bei uns Programm.
 
-- Wir sind ein junges, dynamisches [Team](https://github.com/orgs/NADOOIT/people) - ergänzt um erfahrene Mitarbeitende - welches es sich auf die Fahnen geschrieben hat, mit Innovationen die  IT-Welt voranzubringen und damit einen **wertvollen** Beitrag zum **dringend notwendigen Bürokratie-Abbau** in Deutschland zu leisten.
+- Wir sind ein junges, dynamisches [Team](https://github.com/orgs/NADOOIT/people) - ergänzt um erfahrene Mitarbeitende - welches es sich auf die Fahnen geschrieben hat, mit Innovationen die IT-Welt voranzubringen und damit einen **wertvollen** Beitrag zum **dringend notwendigen Bürokratie-Abbau** in Deutschland zu leisten.
 
 - Wir sind **multikulturell**, **multilingual** und **international** aufgestellt und freuen uns über jede/n, der/die sich uns anschließen möchte.
 - Bei uns werden unterschiedliche Kulturen und Sprachen gelebt und geschätzt, wie das auch in der IT-Welt üblich ist.
@@ -26,17 +27,16 @@ Herzlich willkommen zu deinem Einstieg in deine IT-Karriere bei uns!
 
 ## Das Wiki und unser gelebtes Issue 1st-Prinzip
 
-| |
-| :--- |
-| **WICHTIG**: Bevor du weiterliest, um mit dem Wiki zu starten! |
-| 1. Sende eine eMail mit Deinem GitHub-Benutzernamen an <christoph.backhaus@nadooit.de> |
-| 2. Du erhältst anschließend zeitnah eine eMail, in welcher du aktiv deine Einladung zu diesem öffentlichen Repository bestätigst. |
-| 3. Du kannst dann mit dem Wiki starten und deine ersten Schritte bei der NADOO-IT gehen 🚀 |
+|                                                                                                                                               |
+| :-------------------------------------------------------------------------------------------------------------------------------------------- |
+| **WICHTIG**: Bevor du weiterliest, um mit dem Wiki zu starten!                                                                                |
+| 1. Sende eine eMail mit Deinem GitHub-Benutzernamen an <christoph.backhaus@nadooit.de>                                                        |
+| 2. Du erhältst anschließend zeitnah eine eMail, in welcher du aktiv deine Einladung zu diesem öffentlichen Repository bestätigst.             |
+| 3. Du kannst dann mit dem Wiki starten und deine ersten Schritte bei der NADOO-IT gehen 🚀                                                    |
 | 4. Sollte dabei etwas unverständlich sein, dann erstelle umgehend ein [Issue](https://github.com/NADOOIT/NADOO-Wiki/issues/new/choose) ❗❗❗ |
-| 5. Unsere erfahrenen Kolleginnen und Kollegen werden sich dann zeitnah um dein Anliegen kümmern und dich unterstützen! |
+| 5. Unsere erfahrenen Kolleginnen und Kollegen werden sich dann zeitnah um dein Anliegen kümmern und dich unterstützen!                        |
 
-**Viel Spass und Erfolg bei uns - [Feedback](/docs/01-organisation/07-feedback-kultur/README.md) ist immer willkommen und ausdrücklich erwünscht**  ❗
-
+**Viel Spass und Erfolg bei uns - [Feedback](/docs/01-organisation/07-feedback-kultur/README.md) ist immer willkommen und ausdrücklich erwünscht** ❗
 
 ---
 

--- a/docs/00-willkommen/README.md
+++ b/docs/00-willkommen/README.md
@@ -1,8 +1,12 @@
-# Onboarding und Probemonat
+# <p align="center">Onboarding und Probemonat</p>
 
 ![Willkommen](../../images/onboarding.png)
 
----
+<p align="center">
+<a href="#übersicht-dein-fahrplan-für-den-ersten-tag">➡️ direkt zum First-Day-Fahrplan</a>
+</p>
+
+#
 
 ## Direkte Aufnahme
 
@@ -24,9 +28,11 @@ Sobald du für deinen ersten Tag online kommst, darfst und solltest du dich eins
 
 Wie du das Tool installierst und startest, ist Schritt für Schritt im [**README des Launchpad-Repositories**](https://github.com/NADOOIT/NADOO-Launchpad/blob/main/README.md) beschrieben.
 
-Dieselbe Anleitung findest du außerdem im dedizierten Wiki-Kapitel [**05-Zeiterfassung**](/docs/01-organisation/05-zeiterfassung/README.md) im Abschnitt [**01-organisation**](/docs/01-organisation).
+Dieselbe Anleitung findest du außerdem im dedizierten Wiki-Kapitel [**Das NADOO-Launchpad: Was es kann und wie es funktioniert**](/docs/01-organisation/01-zeiterfassung/01-launchpad-guide/README.md) im Abschnitt [**Zeiterfassung**](/docs/01-organisation/01-zeiterfassung/README.md).
 
-[Hier](/docs/01-organisation/05-zeiterfassung/README.md) wird dir außerdem die **Benutzeroberfläche** des Launchpads im Detail erklärt, damit du ganz genau weißt _wie_ du mit der App deine Zeiten richtig verbuchst und welche Funktionen das Programm sonst noch so bietet.
+<!--Launchoad-Guide zieht in der Ordnerstruktur doch nochmal um, wird dann wieder angepasst-->
+
+[Dort](/docs/01-organisation/01-zeiterfassung/01-launchpad-guide/README.md) wird dir außerdem die **Benutzeroberfläche** des Launchpads im Detail erklärt, damit du ganz genau weißt _wie_ du mit der App deine Zeiten richtig verbuchst und welche Funktionen das Programm sonst noch so bietet.
 
 ⚠️**Wichtig**: Damit das Einstempeln an Tag 1 reibungslos klappt, solltest du dich also am besten im Voraus schon mal mit dem Tool und den zugehörigen Wiki-Abschnitten vertraut machen.
 
@@ -114,8 +120,12 @@ Wir empfehlen dir jedoch, erstmal ganz entspannt anzukommen. Nutze die ersten pa
 
 ## Organisatorisches
 
-Alles, was du zum Thema Organisatorisches wissen musst, findest du im nächsten Wiki-Abschnitt [**01-organisation**](/docs/01-organisation).
+Alles weitere, was du zum Thema Organisatorisches wissen musst, findest du im nächsten Wiki-Themenbereich **Organisation und Rahmenbedingungen**.
 
 Dort wird umfassend auf grundlegende Punkte wie Zeiterfassung, Ausbildungsnachweise, Urlaub, Pausen, Krankmeldung, Umgangskultur und vieles mehr eingegangen.
 
-[Zurück](/README.md) | [Weiter](/docs/01-organisation/01-zeit-ausbildungsnachweise/README.md)
+---
+
+<p align="center">
+<a href="/README.md"><strong>Zurück zur Übersicht</strong></a> | <a href="/docs/01-organisation/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/01-zeiterfassung/01-launchpad-guide/README.md
+++ b/docs/01-organisation/01-zeiterfassung/01-launchpad-guide/README.md
@@ -1,0 +1,37 @@
+# <p align="center">Das NADOO-Launchpad: Was es kann und wie es funktioniert</p>
+
+_Text folgt_
+
+<!--
+
+Mögliche Inhalte / zu beantwortende Fragen:
+
+
+1) Was ist das NADOO-Launchpad?
+
+
+2) Wie installiere ich das NADOO-Launchpad?
+
+-> hier Einleitungen aus dem Launchpad-README per Copy/Paste erneut einfügen
+
+
+3) Welche Funktionen/Komponenten hat das NADOO-Launchpad und welchen Zweck erfüllen sie?
+
+-> ggf. hier auch die Zielgruppe angeben - *für wen* wird der Zweck erfüllt?
+
+
+4) Wie nutze ich die einzelnen Funktionen des NADOO-Launchpads?
+
+-> wichtig ist, dass die Funktionen nicht nur aufgelistet und erklärt wird, wofür/für wen sie sind, sondern auch, WIE man diese dann richtig anwendet
+-> hier sollte die Funktion der Zeiterfassung aufgenommen und umfassend erklärt werden
+
+
+5) idealerweise zum jeweiligen Inhalt passende Screenshots der Benutzeroberfläche integrieren, um den Guide verständlicher und "verdaulicher" zu machen
+
+-->
+
+---
+
+<p align="center">
+<a href="/docs/01-organisation/01-zeiterfassung/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/02-zeit_und_ausbildungsnachweise/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/01-zeiterfassung/README.md
+++ b/docs/01-organisation/01-zeiterfassung/README.md
@@ -1,10 +1,11 @@
 # <p align="center">Zeiterfassung</p>
 
-<!-- <p align="center">
+<p align="center">
 <a href="#dieser-abschnitt-beinhaltet-folgende-kapitel">zur Kapitelübersicht</a>
-</p> -->
+</p>
+<!-- Umstrukturierung geplant: hier nur Anleitung/Kapitel zum Thema Zeiterfassung bzw. Umsetzung mit Launchpad. Launchpad-Guide selbst zieht in den Themenbereich Tools um -->
 
-Die Erfassung deiner Arbeits- und Pausenzeiten erfolgt über unsere Software **NADOO-Launchpad**.
+Die Erfassung deiner **Arbeits- und Pausenzeiten** erfolgt über unsere Software **NADOO-Launchpad**.
 
 Wie das Tool aufgebaut ist und wie du es richtig anwendest, erklärt dir unser [**Launchpad-Guide**](/docs/01-organisation/01-zeiterfassung/01-launchpad-guide/README.md).
 

--- a/docs/01-organisation/01-zeiterfassung/README.md
+++ b/docs/01-organisation/01-zeiterfassung/README.md
@@ -1,5 +1,21 @@
-# Zeiterfassung
+# <p align="center">Zeiterfassung</p>
 
-Die Zeiterfassung erfolgt über die Software NADOO-Launchpad.
+<!-- <p align="center">
+<a href="#dieser-abschnitt-beinhaltet-folgende-kapitel">zur Kapitelübersicht</a>
+</p> -->
+
+Die Erfassung deiner Arbeits- und Pausenzeiten erfolgt über unsere Software **NADOO-Launchpad**.
+
+Wie das Tool aufgebaut ist und wie du es richtig anwendest, erklärt dir unser [**Launchpad-Guide**](/docs/01-organisation/01-zeiterfassung/01-launchpad-guide/README.md).
+
+#
+
+### Dieser Abschnitt beinhaltet folgende Kapitel:
+
+🔹 [**Das NADOO-Launchpad: Was es kann und wie es funktioniert**](/docs/01-organisation/01-zeiterfassung/01-launchpad-guide/README.md) </br>
 
 ---
+
+<p align="center">
+<a href="/docs/01-organisation/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/01-zeiterfassung/01-launchpad-guide/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/02-zeit_und_ausbildungsnachweise/01-beispiele/README.md
+++ b/docs/01-organisation/02-zeit_und_ausbildungsnachweise/01-beispiele/README.md
@@ -1,4 +1,4 @@
-# Beispiele für Ausbildungs- und Zeitnachweise
+# <p align="center">Beispiele für Ausbildungs- und Zeitnachweise</p>
 
 | |
 | :--- |
@@ -102,4 +102,6 @@ Bitte die Anwesenheitsliste immer am dritten Tag des Folgemonats an Musterinstit
 
 ---
 
-[Zurück](/docs/01-organisation/01-zeit-ausbildungsnachweise/README.md) | [Weiter](/docs/01-organisation/01-zeit-ausbildungsnachweise/02-dateibenennung/README.md)
+<p align="center">
+<a href="/docs/01-organisation/02-zeit_und_ausbildungsnachweise/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/02-zeit_und_ausbildungsnachweise/02-dateibenennung/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/02-zeit_und_ausbildungsnachweise/02-dateibenennung/README.md
+++ b/docs/01-organisation/02-zeit_und_ausbildungsnachweise/02-dateibenennung/README.md
@@ -1,4 +1,4 @@
-# Dateibenennungsrichtlinien
+# <p align="center">Dateibenennungsrichtlinien</p>
 
 Diese Regeln wurden entwickelt, um die Bearbeitung der Dateien zu vereinfachen und eine bessere Sortierung zu gewährleisten.
 
@@ -44,4 +44,6 @@ Für weitere Informationen und Einblicke in den Entscheidungsprozess verweisen w
 
 ---
 
-[Zurück](/docs/01-organisation/01-zeit-ausbildungsnachweise/01-beispiele/README.md) | [Weiter](/docs/01-organisation/01-zeit-ausbildungsnachweise/03-ueberpruefung/README.md)
+<p align="center">
+<a href="/docs/01-organisation/02-zeit_und_ausbildungsnachweise/01-beispiele/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/02-zeit_und_ausbildungsnachweise/03-ueberpruefung/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/02-zeit_und_ausbildungsnachweise/03-ueberpruefung/README.md
+++ b/docs/01-organisation/02-zeit_und_ausbildungsnachweise/03-ueberpruefung/README.md
@@ -1,8 +1,9 @@
-# Dateinamen überprüfen
+# <p align="center">Überprüfung der Dateinamen</p>
 
 Dies ist ein Skript, das du in Visual Studio Code einfügen kannst, um zu überprüfen, ob deine Datei gemäß den Benennungsrichtlinien korrekt benannt wurde. Es dient als Beispiel dafür, wie ein Skript zur automatischen Validierung von Dateinamen funktioniert.
 
 Skript:
+
 ```python
 import os
 
@@ -70,4 +71,6 @@ https://github.com/NADOOIT/NADOO-Launchpad/issues/463.
 
 ---
 
-[Zurück](/docs/01-organisation/01-zeit-ausbildungsnachweise/02-dateibenennung/README.md) | [Weiter](/docs/01-organisation/02-arbeits-pausenzeiten/README.md)
+<p align="center">
+<a href="/docs/01-organisation/02-zeit_und_ausbildungsnachweise/02-dateibenennung/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/03-arbeits_und_pausenzeiten/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/02-zeit_und_ausbildungsnachweise/README.md
+++ b/docs/01-organisation/02-zeit_und_ausbildungsnachweise/README.md
@@ -1,7 +1,7 @@
 # <p align="center">Abgabe von Zeit- und Ausbildungsnachweisen</p>
 
 <p align="center">
-<a href="#dieser-abschnitt-beinhaltet-folgende-kapitel">zur Kapitelübersicht</a>
+<a href="#dieser-themen-abschnitt-beinhaltet-folgende-kapitel">zur Kapitelübersicht</a>
 </p>
 
 ---

--- a/docs/01-organisation/02-zeit_und_ausbildungsnachweise/README.md
+++ b/docs/01-organisation/02-zeit_und_ausbildungsnachweise/README.md
@@ -1,10 +1,34 @@
-# Abgabe von Zeit- und Ausbildungsnachweisen
+# <p align="center">Abgabe von Zeit- und Ausbildungsnachweisen</p>
 
-- Du bist verpflichtet, deinen Zeitnachweis sowie den Ausbildungsnachweis bis zum **6. des Folgemonats um 23:59 Uhr** einzureichen.
-- Wird diese Frist nicht eingehalten, erfolgt eine sofortige Kündigung.
-- Diese Regelung trainiert Pünktlichkeit und termingerechtes Arbeiten – Eigenschaften, die in der Arbeitswelt hoch geschätzt werden.
-- Alle Dateien an  **Email:** [christoph.backhaus@nadooit.de](mailto:christoph.backhaus@nadooit.de) senden.
+<p align="center">
+<a href="#dieser-abschnitt-beinhaltet-folgende-kapitel">zur Kapitelübersicht</a>
+</p>
 
 ---
 
-[Zurück](/docs/00-willkommen/README.md) | [Weiter](/docs/01-organisation/01-zeit-ausbildungsnachweise/01-beispiele/README.md)
+### Hier sind die wichtigsten Regeln zum Thema Zeit- und Ausbildungsnachweise zusammengefasst:
+
+#
+
+1. Du bist verpflichtet, deinen Zeitnachweis sowie den Ausbildungsnachweis bis zum **6. des Folgemonats um 23:59 Uhr** einzureichen.
+
+2. Wird diese Frist nicht eingehalten, erfolgt eine sofortige Kündigung.
+   Diese Regelung trainiert Pünktlichkeit und termingerechtes Arbeiten – Eigenschaften, die in der Arbeitswelt hoch geschätzt werden.
+
+3. Alle Dateien müssen via **Email** an [**christoph.backhaus@nadooit.de**](mailto:christoph.backhaus@nadooit.de) gesendet werden.
+
+#
+
+### Dieser Themen-Abschnitt beinhaltet folgende Kapitel:
+
+#
+
+🔹 [**Beispiele für Ausbildungs- und Zeitnachweise**](/docs/01-organisation/02-zeit_und_ausbildungsnachweise/01-beispiele/README.md) </br>
+🔹 [**Dateibenennungsrichtlinien**](/docs/01-organisation/02-zeit_und_ausbildungsnachweise/02-dateibenennung/README.md) </br>
+🔹 [**Überprüfung der Dateinamen**](/docs/01-organisation/02-zeit_und_ausbildungsnachweise/03-ueberpruefung/README.md) </br>
+
+---
+
+<p align="center">
+<a href="/docs/01-organisation/01-zeiterfassung/01-launchpad-guide/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/02-zeit_und_ausbildungsnachweise/01-beispiele/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/03-arbeits_und_pausenzeiten/README.md
+++ b/docs/01-organisation/03-arbeits_und_pausenzeiten/README.md
@@ -1,56 +1,71 @@
-# Arbeitszeit & Pausen
+# <p align="center">Arbeitszeit & Pausen</p>
 
-| |
-|:--- |
-| Unsere täglichen Meetings und festgelegten Ruhezeiten (mindestens 11 Stunden zwischen den Arbeitstagen) sind **verbindlich einzuhalten.** Die maximale Arbeitszeit endet um 23:00 Uhr. |
+Unsere täglichen [**Meetings**](/docs/03-meetings/README.md) und festgelegten **Ruhezeiten** (mindestens 11 Stunden zwischen den Arbeitstagen) sind **verbindlich einzuhalten.** Es muss um **spätestens 23:00 Uhr Feierabend** gemacht werden.
 
+</br>
 
 ## Arbeitszeiten nach [Arbeitszeitgesetz](https://www.gesetze-im-internet.de/arbzg/BJNR117100994.html)
 
 - **§3 Stunden:**
-  - 8 Stunden pro Tag (**durchschnittlich**, auf 24 Wochen berechnet)
-  - Maximal 10 Stunden pro Tag  
+
+  ➡️ 8 Stunden pro Tag (**durchschnittlich**, auf 24 Wochen berechnet) </br>
+  ➡️ Maximal 10 Stunden pro Tag </br>
+
   Wenn jemand also Montag, Dienstag, Mittwoch und Donnerstag jeweils 9 Stunden arbeitet, darf er am Freitag maximal 4 Stunden arbeiten.
 
 ---
 
 - **§4 Pausen:**
-  - Nach 6 Stunden Arbeit: mindestens 30 Minuten Pause (**spätestens!**)
-  - Nach 9 Stunden Arbeit insgesamt: noch einmal mindestens 15 Minuten Pause
-  - Mindestdauer einer Pause: 15 Minuten
+
+  ➡️ Nach 6 Stunden Arbeit: mindestens 30 Minuten Pause (**spätestens!**) </br>
+  ➡️ Nach 9 Stunden Arbeit insgesamt: noch einmal mindestens 15 Minuten Pause </br>
+  ➡️ Mindestdauer einer Pause: 15 Minuten
 
 ---
 
 - **§5 Ruhezeiten:**
-  - Mindestdauer einer Ruhezeit: 11 Stunden  
+
+  ➡️ Mindestdauer einer Ruhezeit: 11 Stunden </br>
+
   Wenn jemand zum Beispiel von 12:00 Uhr bis 20:30 Uhr arbeitet (8 Stunden + 30 Minuten Pause), darf er am nächsten Tag frühestens um 07:30 mit der Arbeit beginnen.
 
 ---
 
-- **§9 Sonntage & Feiertage:**  
-  Hier darf niemand zwischen 00:00 und 24:00 Uhr arbeiten
+- **§9 Sonntage & Feiertage:**
+
+  ❗ Hier darf niemand zwischen 00:00 und 24:00 Uhr arbeiten
 
 ---
+
+</br>
 
 ### Arbeitszeiten bei Nadoo-IT
 
-- Montag bis Samstag: zwischen 06:00 Uhr und 23:00 Uhr
-- Arbeitsstunden pro Woche nach persönlichem Praktikumsvertrag (z.B. 40 Stunden oder 28 Stunden)
-- Arbeitszeiterfassung über die Stempeluhr (nur erfasste Arbeitszeit ist echte Arbeitszeit!)
-- Mo-Fr um 10:14 Uhr - 10:30 Uhr Anwesenheitsprüfung im Discord Sprachkanal
-- Arbeitszeiten pro Tag sind frei wählbar, solange das Arbeitszeitgesetz und die hier genannten Punkte eingehalten werden
+🕒 **Montag bis Samstag:** zwischen 06:00 Uhr und 23:00 Uhr
+
+🕒 **Montag bis Freitag von 10:14 Uhr - 10:30 Uhr:** Anwesenheitsprüfung im Discord Sprachkanal
+
+🕒 **Arbeitsstunden pro Woche:** nach persönlichem Praktikumsvertrag (z.B. 40 Stunden oder 28 Stunden)
+
+🕒 **Arbeitszeiten pro Tag**: frei wählbar, solange das Arbeitszeitgesetz, Wochenstunden und Pflichtmeetings eingehalten werden
+
+🕒 **Arbeitszeiterfassung**: über die Stempeluhr im [**NADOO-Launchpad**](docs/01-organisation/01-zeiterfassung/01-launchpad-guide/README.md) (nur erfasste Arbeitszeit ist echte Arbeitszeit!)
 
 ---
 
-#### Beispiel Fritz (28 Stunden / Woche)
-
-- Montags arbeitet er von 10:00 bis 12:00 Uhr und von 14:00 bis 16:00 Uhr. (2 Stunden + 2 Stunden = 4 Stunden)
-- Dienstags arbeitet er von 10:00 bis 14:00 Uhr und von 16:00 bis 18:00 Uhr. (4 Stunden + 2 Stunden = 6 Stunden)
-- Mittwochs arbeitet er von 10:00 bis 14:00 Uhr und von 16:00 bis 20:00 Uhr. (4 Stunden + 4 Stunden = 8 Stunden)
-- Donnerstags arbeitet er von 10:00 bis 14:00 Uhr und von 16:00 bis 18:00 Uhr. (4 Stunden + 2 Stunden = 6 Stunden)
-- Freitags arbeitet er von 10:00 bis 14:00 Uhr. (4 Stunden)
-- Samstags und Sonntags arbeitet er nicht.
+#### Beispiel "Fritz" (28 Stunden / Woche):
 
 ---
 
-[Zurück](/docs/01-organisation/01-zeit-ausbildungsnachweise/03-ueberpruefung/README.md) | [Weiter](/docs/01-organisation/03-urlaub/README.md)
+✔️ Montags arbeitet er von 10:00 bis 12:00 Uhr und von 14:00 bis 16:00 Uhr. ➡️ 2 Stunden + 2 Stunden = **4** Stunden <br>
+✔️ Dienstags arbeitet er von 10:00 bis 14:00 Uhr und von 16:00 bis 18:00 Uhr. ➡️ 4 Stunden + 2 Stunden = **6** Stunden <br>
+✔️ Mittwochs arbeitet er von 10:00 bis 14:00 Uhr und von 16:00 bis 20:00 Uhr. ➡️ 4 Stunden + 4 Stunden = **8** Stunden <br>
+✔️ Donnerstags arbeitet er von 10:00 bis 14:00 Uhr und von 16:00 bis 18:00 Uhr. ➡️ 4 Stunden + 2 Stunden = **6** Stunden <br>
+✔️ Freitags arbeitet er von 10:00 bis 14:00 Uhr. ➡️ **4** Stunden <br>
+❌ Samstags und Sonntags arbeitet er nicht. <br>
+
+---
+
+<p align="center">
+<a href="/docs/01-organisation/02-zeit_und_ausbildungsnachweise/03-ueberpruefung/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/04-urlaub/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/04-urlaub/README.md
+++ b/docs/01-organisation/04-urlaub/README.md
@@ -1,4 +1,4 @@
-# Urlaubsregelung
+# <p align="center">Urlaubsregelung</p>
 
 ## Anzahl der Urlaubstage
 
@@ -10,6 +10,8 @@ Die Anzahl der Urlaubstage richtet sich nach den Bestimmungen des individuellen 
 
 Der Urlaubsantrag sollte spätestens einen Tag vor dem geplanten Urlaubsantritt gestellt werden.
 
+<!-- Antragsstellung um genauere Infos ergänzen (siehe issue #387) -->
+
 ---
 
 ## Verrechnung von Fehltagen
@@ -18,4 +20,6 @@ Nicht genehmigte Fehltage werden automatisch als Urlaubstage verrechnet. Sollte 
 
 ---
 
-[Zurück](/docs/01-organisation/02-arbeits-pausenzeiten/README.md) | [Weiter](/docs/01-organisation/04-krankmeldungen/README.md)
+<p align="center">
+<a href="/docs/01-organisation/03-arbeits_und_pausenzeiten/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/05-krankmeldungen/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/05-krankmeldungen/README.md
+++ b/docs/01-organisation/05-krankmeldungen/README.md
@@ -1,9 +1,13 @@
-# Krankmeldungen
+# <p align="center">Krankmeldungen</p>
 
-Melde dich bitte bei Krankheit bis spätestens 11:00 Uhr – sowohl direkt bei Christoph Backhaus, dem zuständigen Institut und deinem Kostenträger (Arbeitsagentur oder Jobcenter).
+Melde dich bitte bei Krankheit **bis spätestens 11:00 Uhr** als erstes direkt **bei Christoph** ab. Benachrichtige im Anschluss ebenfalls dein zuständiges **Bildungsinstitut** sowie deinen **Kostenträger** (Arbeitsagentur oder Jobcenter).
+
+<!-- bei Christoph nachfragen: Deadline sicher bis 11 Uhr? obwohl Anwesenheitskontrolle zu dem Zeitpunkt bereits durchgefürt und in einem anderen Schritt ausgesagt wurde, dass man dann als abwesend gilt? -->
 
 **Fehlende oder verspätete Meldungen gelten als Abwesenheit und können entsprechende Konsequenzen haben!**
 
 ---
 
-[Zurück](/docs/01-organisation/03-urlaub/README.md) | [Weiter](/docs/01-organisation/05-zeiterfassung/README.md)
+<p align="center">
+<a href="/docs/01-organisation/04-urlaub/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/06-mutterschutz_und_elternzeit/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/06-mutterschutz_und_elternzeit/README.md
+++ b/docs/01-organisation/06-mutterschutz_und_elternzeit/README.md
@@ -1,11 +1,14 @@
-# Mutterschutz & Elternzeit
+# <p align="center">Mutterschutz & Elternzeit</p>
 
-Gesetzliche Regelungen zum Mutterschutz und zur Elternzeit sind in Deutschland im [Mutterschutzgesetz (MuSchG)](https://www.gesetze-im-internet.de/muschg_2018/) und im [Bundeselterngeld- und Elternzeitgesetz (BEEG)](https://www.gesetze-im-internet.de/beeg/) festgelegt.
+Gesetzliche Regelungen zum Mutterschutz und zur Elternzeit sind in Deutschland im [**Mutterschutzgesetz (MuSchG)**](https://www.gesetze-im-internet.de/muschg_2018/) und im [**Bundeselterngeld- und Elternzeitgesetz (BEEG)**](https://www.gesetze-im-internet.de/beeg/) festgelegt.
 
 Diese Gesetze regeln den Schutz von Müttern und Vätern vor und nach der Geburt eines Kindes sowie die Möglichkeit, Elternzeit zu nehmen.
 
-Diese Regelungen gelten für Arbeitnehmerinnen und Arbeitnehmer, die in einem Arbeitsverhältnis stehen.
+Diese Regelungen gelten für **alle** Arbeitnehmerinnen und Arbeitnehmer, die in einem Arbeitsverhältnis stehen.
 
+<!-- Vorschlag: hier evtl. noch kleine Übersicht der wichtigsten Punkte/Regelungen anfügen, damit Betroffene sich im Falle des Falles nicht erst durch 300 Seiten Gesetzestext kämpfen müssen -->
 ---
 
-[Zurück](/docs/01-organisation/07-feedback-kultur/README.md) | [Weiter](/docs/01-organisation/09-jobrotation-weiterbildung/README.md)
+<p align="center">
+<a href="/docs/01-organisation/05-krankmeldungen/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/07-datenschutz/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/07-datenschutz/README.md
+++ b/docs/01-organisation/07-datenschutz/README.md
@@ -1,69 +1,65 @@
-<<<<<<<< HEAD:docs/01-organisation/07-datenschutz/README.md
-# Umgang mit Unternehmensdaten bei Christoph Backhaus / NADOO-IT: Sicherheit und Vertraulichkeit als oberste Priorität
-========
-# Umgang mit Unternehmensdaten bei Christoph Backhaus IT: Sicherheit und Vertraulichkeit als oberste Priorität
->>>>>>>> main:docs/01-organisation/06-verhalten-umgang/01-datenschutz/README.md
+# <p align="center">Umgang mit Unternehmensdaten bei Christoph Backhaus IT: Sicherheit und Vertraulichkeit als oberste Priorität</p>
 
 ## Einführung
 
 Dieser Wiki-Artikel ist ein wesentlicher Bestandteil unseres Onboarding-Prozesses und vermittelt unsere Richtlinien zum Umgang mit Unternehmensdaten. Der Schutz sensibler Informationen, einschließlich des entwickelten Codes, ist für uns von höchster Bedeutung.
 
----
+#
 
 ## Grundprinzipien
 
-- Absolute Vertraulichkeit aller Unternehmensdaten und des entwickelten Codes
-- Strikte Trennung von privater und geschäftlicher Kommunikation
-- Lokale Datenspeicherung und kontrollierte Datenübertragung
-- Transparenz und Genehmigungspflicht bei der Datenverarbeitung
+➡️ Absolute Vertraulichkeit aller Unternehmensdaten und des entwickelten Codes <br>
+➡️ Strikte Trennung von privater und geschäftlicher Kommunikation <br>
+➡️ Lokale Datenspeicherung und kontrollierte Datenübertragung <br>
+➡️ Transparenz und Genehmigungspflicht bei der Datenverarbeitung <br>
 
 ---
 
 ## E-Mail-Kommunikation
 
-- Eine DSGVO-konforme E-Mail-Adresse ist ausschließlich für die Unternehmenskommunikation zu verwenden
-- Diese E-Mail-Adresse darf nur für unternehmensbezogene Dienste genutzt werden
-- Ziel ist die Prävention von Phishing, Spearfishing und anderen Cyberangriffen
+📧 Eine DSGVO-konforme E-Mail-Adresse ist ausschließlich für die Unternehmenskommunikation zu verwenden <br>
+📧 Diese E-Mail-Adresse darf nur für unternehmensbezogene Dienste genutzt werden <br>
+📧 Ziel ist die Prävention von Phishing, Spearfishing und anderen Cyberangriffen <br>
 
 ---
 
 ## Umgang mit Kundendaten und Code
 
-- Kundendaten und entwickelter Code sind streng vertraulich zu behandeln
-- Keine externe Verarbeitung oder Speicherung ohne Genehmigung
-- Verbot der Nutzung von Cloud-Diensten wie OneDrive oder Google Drive
-- Keine Verwendung externer Datenverarbeitungstools oder KI-Systeme für Unternehmensdaten oder Code
+➡️ Kundendaten und entwickelter Code sind streng vertraulich zu behandeln <br>
+➡️ Keine externe Verarbeitung oder Speicherung ohne Genehmigung <br>
+➡️ Verbot der Nutzung von Cloud-Diensten wie OneDrive oder Google Drive <br>
+➡️ Keine Verwendung externer Datenverarbeitungstools oder KI-Systeme für Unternehmensdaten oder Code <br>
 
 ---
 
 ## Datenspeicherung und -übertragung
 
-- Daten und Code sind lokal auf dem Computer oder auf ausgehändigten Speichermedien abzulegen
-- Für notwendige Datenübertragungen ist das Tool "Magic Wormhole" zu verwenden
-- Die Nutzung von Diensten wie WeTransfer ist untersagt
+💾 Daten und Code sind lokal auf dem Computer oder auf ausgehändigten Speichermedien abzulegen <br>
+💾 Für notwendige Datenübertragungen ist das Tool "Magic Wormhole" zu verwenden <br>
+💾 Die Nutzung von Diensten wie WeTransfer ist untersagt <br>
 
 ---
 
 ## Genehmigungspflicht
 
-- Jede Weitergabe von Daten oder Code nach extern bedarf der Zustimmung des Geschäftsführers
-- Neue Speicherorte oder -methoden sind vorab abzuklären
+➡️ Jede Weitergabe von Daten oder Code nach extern bedarf der Zustimmung des Geschäftsführers <br>
+➡️ Neue Speicherorte oder -methoden sind vorab abzuklären <br>
 
 ---
 
 ## Meldepflicht
 
-- Jegliche Abweichung von diesen Richtlinien ist umgehend dem Geschäftsführer zu melden
+💬 Jegliche Abweichung von diesen Richtlinien ist umgehend dem Geschäftsführer zu melden <br>
 
 ---
 
 ## Wichtiger Hinweis
 
-Diese Richtlinien gelten für alle im Kontext der Zusammenarbeit mit unserem Unternehmen erstellten Programme und Daten. Für persönliche, nicht mit dem Unternehmen zusammenhängende Projekte sind diese Regeln nicht zwingend erforderlich. Jedoch muss jegliche anderweitige Behandlung von Unternehmensdaten oder -code mit der Geschäftsführung abgesprochen und freigegeben werden.
+Diese Richtlinien gelten für **alle im Kontext der Zusammenarbeit mit unserem Unternehmen erstellten Programme und Daten**. Für persönliche, nicht mit dem Unternehmen zusammenhängende Projekte sind diese Regeln nicht zwingend erforderlich. Jedoch muss jegliche anderweitige Behandlung von Unternehmensdaten oder -code mit der Geschäftsführung abgesprochen und freigegeben werden.
 
-Die strikte Einhaltung dieser Richtlinien ist für den Schutz unserer Unternehmensdaten, unseres geistigen Eigentums und die Wahrung des Vertrauens unserer Kunden unerlässlich. Jeder Mitarbeiter trägt die Verantwortung, diese Regeln zu befolgen und somit zur Sicherheit und Integrität unseres Unternehmens beizutragen.
+Die strikte Einhaltung dieser Richtlinien ist für den **Schutz** unserer **Unternehmensdaten**, unseres **geistigen Eigentums** und die Wahrung des **Vertrauens unserer Kunden** unerlässlich. Jeder Mitarbeiter trägt die Verantwortung, diese Regeln zu befolgen und somit zur **Sicherheit und Integrität** unseres Unternehmens beizutragen.
 
----
+#
 
 **Quellen / Zitate**:
 
@@ -71,4 +67,6 @@ Die strikte Einhaltung dieser Richtlinien ist für den Schutz unserer Unternehme
 
 ---
 
-[Zurück](../../06-verhalten-umgang/README.md) | [Weiter](../../07-feedback-kultur/README.md) zu Feedback-Kultur
+<p align="center">
+<a href="/docs/01-organisation/06-mutterschutz_und_elternzeit/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/08-firmenphilosophie/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/08-firmenphilosophie/01-verhaltensregeln/README.md
+++ b/docs/01-organisation/08-firmenphilosophie/01-verhaltensregeln/README.md
@@ -1,36 +1,35 @@
-# Verhaltensregeln bei Christoph Backhaus / NADOO-IT
-
----
+# <p align="center">Verhaltensregeln bei Christoph Backhaus / NADOO-IT</p>
 
 ## Pünktlichkeit & Termingerechtes Arbeiten
 
-Halte die festgelegten Zeiten (z. B. Anwesenheitscheck, Abgabe von Nachweisen) strikt ein. Dies ist entscheidend für einen reibungslosen Ablauf und den Erfolg unserer Projekte.
+Halte die **festgelegten Zeiten** (z. B. Anwesenheitscheck, Abgabe von Nachweisen) strikt ein. Dies ist entscheidend für einen reibungslosen Ablauf und den Erfolg unserer Projekte.
 
 ---
 
 ## Transparenz & Feedback-Kultur
 
-Jede Rückmeldung, ob groß oder klein, ist wertvoll. Nutze den ["Issue-first"-Ansatz](https://github.com/NADOOIT/NADOO-Launchpad/issues/new/choose) in **GitHub**, um Verbesserungsvorschläge, Fehler oder Ideen zu dokumentieren.
+Jede Rückmeldung, ob groß oder klein, ist wertvoll. Nutze den [**"Issue-first"-Ansatz**](/docs/01-organisation/08-firmenphilosophie/02-feedback-kultur/README.md/#issue-first-prinzip--probleme-sichtbar-machen-um-lösungen-zu-finden) mittels [**GitHub**](/docs/04-tools/01-github/README.md), um **Verbesserungsvorschläge**, **Fehler** oder **Ideen** zu dokumentieren.
 
 ---
 
 ### Teamarbeit & Kommunikation
 
-Arbeite eng mit Deinen Mentoren, Teamkoordinatoren und Lernpartnern zusammen. Nutze Discord und unsere regelmäßigen Meetings, um Fragen zu klären und Wissen auszutauschen.
+Arbeite eng mit deinen erfahrenen **Team-Kollegen**, **Teamkoordinatoren** und **Lernpartnern** zusammen. Nutze Discord und unsere regelmäßigen Meetings, um Fragen zu klären und Wissen auszutauschen.
 
----
+<!-- Thema Lernpartner: wird so in der Form aktuell auch nicht (mehr?) umgesetzt. am besten bei Christoph nachfragen, ob das noch/wieder in den Prozess aufgenommen werden soll -->
 
 ## Verantwortungsübernahme
 
-Zeige Eigeninitiative und übernimm Verantwortung – sowohl in Deiner täglichen Arbeit als auch in der Dokumentation und Weiterentwicklung unserer Prozesse.
+Zeige **Eigeninitiative** und übernimm **Verantwortung** – sowohl in deiner täglichen Arbeit als auch in der **Dokumentation** und **Weiterentwicklung** unserer Prozesse.
 
 ---
 
-### Videopflicht in Discord
+## Videopflicht in Discord
 
-**Videopflicht**: Während unserer Meetings ist Videoanwesenheit Pflicht – alternativ können virtuelle Avatare genutzt werden. Eine detaillierte Anleitung zur Einrichtung eines Avatars findest Du in Kürze in unserem Wiki.
-Während unserer Meetings ist Videoanwesenheit Pflicht – alternativ können virtuelle Avatare genutzt werden. Eine detaillierte Anleitung zur Einrichtung eines Avatars findest Du in Kürze in unserem Wiki.
+Während unserer Meetings ist Videoanwesenheit **Pflicht** – alternativ können **virtuelle Avatare** genutzt werden. Eine detaillierte Anleitung zur Einrichtung eines Avatars findest du in Kürze in unserem Wiki.
 
----
+<!-- zum virtuellen Avatar: gibt's da schon was zum Verlinken bzw. hat das irgendwer noch auf dem Zettel? -->
 
-Zurück | [Weiter](/docs/01-organisation/07-feedback-kultur/README.md)
+<p align="center">
+<a href="/docs/01-organisation/08-firmenphilosophie/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/08-firmenphilosophie/02-feedback-kultur/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/08-firmenphilosophie/02-feedback-kultur/README.md
+++ b/docs/01-organisation/08-firmenphilosophie/02-feedback-kultur/README.md
@@ -1,18 +1,16 @@
-# Feedback-Kultur
+# <p align="center">Feedback-Kultur bei Christoph Backhaus IT</p>
 
-## Feedback-Kultur bei NADOO-IT
-
-### Offene Kommunikation als Grundlage für gemeinsames Wachstum
+## Offene Kommunikation als Grundlage für gemeinsames Wachstum
 
 Bei NADOO-IT ist Feedback keine Einbahnstraße, sondern ein zentraler Bestandteil unserer Unternehmenskultur.
 
-Unsere Arbeitsweise basiert auf Transparenz, gegenseitigem Respekt und dem gemeinsamen Ziel, voneinander zu lernen und uns kontinuierlich weiterzuentwickeln.
+Unsere Arbeitsweise basiert auf **Transparenz**, **gegenseitigem Respekt** und dem gemeinsamen Ziel, **voneinander** zu **lernen** und uns kontinuierlich **weiterzuentwickeln**.
 
-Dabei gilt für alle Teammitglieder – unabhängig von Erfahrung oder Rolle – der Grundsatz: **Es gibt keine dummen Fragen** ❗
+#
 
----
+**Dabei gilt für alle Teammitglieder – unabhängig von Erfahrung oder Rolle – der Grundsatz:**
 
-## Es gibt keine dummen Fragen! – nur unbeantwortete?
+## Es gibt keine dummen Fragen! – Nur unbeantwortete. 😎
 
 **Fragen sind der Motor unseres Fortschritts!**
 
@@ -26,27 +24,28 @@ Unsere Unternehmensziele spiegeln diesen Anspruch wider: Wir wollen wachsen – 
 
 ## Issue-First-Prinzip – Probleme sichtbar machen, um Lösungen zu finden
 
-Ein zentrales Element unserer Feedback-Kultur ist das Issue-First-Prinzip. Statt Probleme unter den Teppich zu kehren oder still zu ertragen, benennen wir sie aktiv und strukturiert – zum Beispiel durch [GitHub-Issues](https://github.com/NADOOIT/NADOO-Wiki/issues/new/choose), Feedback-Sessions oder offene Team-Meetings.
+Ein zentrales Element unserer Feedback-Kultur ist das **Issue-First-Prinzip**. Statt Probleme unter den Teppich zu kehren oder still zu ertragen, benennen wir sie aktiv und strukturiert – in erster Linie mithilfe von [**GitHub-Issues**](/docs/04-tools/01-github/04-issues/README.md) - aber auch in **Feedback-Sessions** oder **offenen** [**Team-Meetings**](/docs/03-meetings/README.md).
+Nur das, was **für alle sichtbar** ist, kann durch uns auch **gemeinsam** gelöst werden.
 
-Nur was für uns alle sichtbar ist, kann auch durch uns **gemeinsam** gelöst werden❗
+Diese Offenheit schafft **Vertrauen** und sorgt dafür, dass sich niemand mit Herausforderungen alleingelassen fühlt.
 
-Nur diese Offenheit schafft Vertrauen und sorgt dafür, dass sich niemand mit Herausforderungen alleingelassen fühlt.
-
----
+--- 
 
 ## Wie wir Feedback leben
 
-- **Konstruktiv & konkret**: Feedback ist bei uns keine Kritik an der Person, sondern ein Beitrag zur Verbesserung.
-- **Auf Augenhöhe**: Jede Meinung zählt – vom Azubi bis zur Geschäftsführung.
-- **Verbindlich & nachvollziehbar**: Feedback wird dokumentiert, priorisiert und in Verbesserungsmaßnahmen übersetzt.
-- **Regelmäßig & strukturiert**: In Weeklies, Retros und 1:1-Gesprächen ist Feedback ein fester Bestandteil.
+✅ **Konstruktiv & konkret**: Feedback ist bei uns keine Kritik an der Person, sondern ein Beitrag zur Verbesserung. <br>
+✅ **Auf Augenhöhe**: Jede Meinung zählt – vom Azubi bis zur Geschäftsführung. <br>
+✅ **Verbindlich & nachvollziehbar**: Feedback wird dokumentiert, priorisiert und in Verbesserungsmaßnahmen übersetzt. <br>
+✅ **Regelmäßig & strukturiert**: In Weeklies (wöchentlichen Meetings), Retros (Rückblick und Refklektion gemeisterter Arbeit) und 1:1-Gesprächen ist Feedback ein fester Bestandteil. <br>
 
 ---
 
 ## Fazit
 
-Unsere Feedback-Kultur ist kein Zusatz, sondern integraler Bestandteil der NADOO-DNA. Sie sorgt dafür, dass wir als Team wachsen, Innovation ermöglichen und Herausforderungen mutig begegnen können. Fragen, die offen gestellt und Themen, die sichtbar gemacht werden, sind der erste Schritt in Richtung Lösung – und genau diesen Schritt fördern wir jeden Tag.
+Unsere Feedback-Kultur ist kein Zusatz, sondern integraler Bestandteil der NADOO-DNA. Sie sorgt dafür, dass wir **als Team wachsen**, **Innovation** ermöglichen und **Herausforderungen** mutig begegnen können. Fragen, die offen gestellt und Themen, die sichtbar gemacht werden, sind der erste Schritt in Richtung Lösung – und genau diesen Schritt fördern wir jeden Tag.
 
 ---
 
-[Zurück](/docs/01-organisation/06-verhalten-umgang/README.md) | [Weiter](/docs/01-organisation/08-mutterschutz-elternzeit/README.md)
+<p align="center">
+<a href="/docs/01-organisation/08-firmenphilosophie/01-verhaltensregeln/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/08-firmenphilosophie/03-kaizen/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/08-firmenphilosophie/03-kaizen/README.md
+++ b/docs/01-organisation/08-firmenphilosophie/03-kaizen/README.md
@@ -1,8 +1,8 @@
-# KAIZEN bei Christoph Backhaus IT: Eine Kultur der kontinuierlichen Verbesserung
+# <p align="center">KAIZEN bei Christoph Backhaus IT: Eine Kultur der kontinuierlichen Verbesserung</p>
 
 ## Einführung
 
-Willkommen bei Christoph Backhaus IT. Dieser Wiki-Artikel ist ein wesentlicher Bestandteil deines Onboarding-Prozesses und soll dir einen umfassenden Einblick in unsere Unternehmenskultur geben. Unsere Philosophie basiert auf dem KAIZEN-Prinzip, einem japanischen Konzept, das "Veränderung zum Besseren" bedeutet. Wir haben dieses Konzept, das sich in der Automobilindustrie bewährt hat, erfolgreich auf die Softwareentwicklung übertragen.
+Dieser Wiki-Artikel ist ein wesentlicher Bestandteil deines Onboarding-Prozesses und soll dir einen umfassenden Einblick in unsere Unternehmenskultur geben. Unsere Philosophie basiert auf dem KAIZEN-Prinzip, einem japanischen Konzept, das "**Veränderung zum Besseren**" bedeutet. Im Laufe der Jahre wurde dieses Konzept, das sich in der Automobilindustrie bewährt hat, erfolgreich auf die Softwareentwicklung übertragen.
 
 ## Geschichte und Ursprung von KAIZEN
 
@@ -14,88 +14,125 @@ In der Automobilindustrie bedeutet KAIZEN, dass jeder Mitarbeiter, unabhängig v
 
 Bei Christoph Backhaus IT haben wir die KAIZEN-Philosophie auf die Softwareentwicklung übertragen. Unsere Grundprinzipien sind:
 
-1. **Fehlerfreiheit als oberste Priorität**: Wir betrachten Bugs und Fehler als wertvolle Lernmöglichkeiten.
-2. **Methodische Prozesssauberkeit**: Dies ist entscheidend für unseren gemeinsamen Erfolg.
-3. **Kontinuierliche Verbesserung**: Wir streben danach, jeden Tag ein bisschen besser zu werden.
-4. **Einbeziehung aller Mitarbeiter**: Jeder ist aktiv an der Verbesserung von Prozessen beteiligt.
-5. **Qualität vor Quantität**: Unser Fokus liegt darauf, durch sorgfältige Fehlerbehebung höchste Qualität zu erreichen.
-6. **Offene Kommunikation**: Fehler werden offen besprochen, um gemeinsam Lösungen zu finden.
+> **1. Fehlerfreiheit als oberste Priorität**: Wir betrachten Bugs und Fehler als wertvolle Lernmöglichkeiten.
+
+> **2. Methodische Prozesssauberkeit**: Dies ist entscheidend für unseren gemeinsamen Erfolg.
+
+> **3. Kontinuierliche Verbesserung**: Wir streben danach, jeden Tag ein bisschen besser zu werden.
+
+> **4. Einbeziehung aller Mitarbeiter**: Jeder ist aktiv an der Verbesserung von Prozessen beteiligt.
+
+> **5. Qualität vor Quantität**: Unser Fokus liegt darauf, durch sorgfältige Fehlerbehebung höchste Qualität zu erreichen.
+
+> **6. Offene Kommunikation**: Fehler werden offen besprochen, um gemeinsam Lösungen zu finden.
+
+---
 
 ## Praktische Umsetzung von KAIZEN in der Softwareentwicklung
 
 ### 5S in der Softwareentwicklung
 
-Die 5S-Methode, ursprünglich für die Organisation von Arbeitsplätzen in Fabriken entwickelt, lässt sich hervorragend auf den digitalen Arbeitsplatz eines Softwareentwicklers übertragen[1]:
+Die 5S-Methode, ursprünglich für die **Organisation von Arbeitsplätzen** in Fabriken entwickelt, lässt sich hervorragend auf den digitalen Arbeitsplatz eines Softwareentwicklers übertragen[1]:
 
-1. **Sortieren (Seiri)**: Entferne ungenutzte Dateien, alte Codeversionen und überflüssige Tools von deinem System.
-2. **Systematisieren (Seiton)**: Organisiere deinen Code, deine Projekte und deine Entwicklungsumgebung logisch und effizient.
-3. **Säubern (Seiso)**: Führe regelmäßig Code-Cleanups durch und beseitige technische Schulden.
-4. **Standardisieren (Seiketsu)**: Etabliere Coding-Standards und Best Practices im Team.
-5. **Selbstdisziplin (Shitsuke)**: Halte dich konsequent an die etablierten Standards und verbessere diese kontinuierlich.
+> **1. Sortieren (Seiri)**: Entferne ungenutzte Dateien, alte Codeversionen und überflüssige Tools von deinem System.
 
-### PDCA-Zyklus in der Softwareentwicklung
+> **2. Systematisieren (Seiton)**: Organisiere deinen Code, deine Projekte und deine Entwicklungsumgebung logisch und effizient.
 
-Der PDCA-Zyklus ist ideal für die iterative Entwicklung und Problemlösung[1]:
+> **3. Säubern (Seiso)**: Führe regelmäßig Code-Cleanups durch und beseitige technische Schulden.
 
-1. **Plan**: Erstelle ein Issue, welches das Problem oder gewünschte Feature klar beschreibt.
-2. **Do**: Erstelle einen Branch und implementiere ein Minimum Viable Product (MVP) oder einen Bugfix.
-3. **Check**: Führe Tests durch und erstelle einen Pull Request für ein Code Review.
-4. **Act**: Führe einen finalen Merge durch, nachdem der Feedback-Loop abgeschlossen ist und Fehlerfreiheit erreicht wurde.
+> **4. Standardisieren (Seiketsu)**: Etabliere Coding-Standards und Best Practices im Team.
+
+> **5. Selbstdisziplin (Shitsuke)**: Halte dich konsequent an die etablierten Standards und verbessere diese kontinuierlich.
+
+---
+
+### Der PDCA-Zyklus in der Softwareentwicklung
+
+Der PDCA-Zyklus ist ideal für die **iterative Entwicklung und Problemlösung**[1]:
+
+> **1. Plan**: Erstelle ein Issue, welches das Problem oder gewünschte Feature klar beschreibt.
+
+> **2. Do**: Erstelle einen Branch und implementiere ein Minimum Viable Product (MVP) oder einen Bugfix.
+
+> **3. Check**: Führe Tests durch und erstelle einen Pull Request für ein Code Review.
+
+> **4. Act**: Führe einen finalen Merge durch, nachdem der Feedback-Loop abgeschlossen ist und Fehlerfreiheit erreicht wurde.
+
+---
 
 ### Gemba Walks in der Softwareentwicklung
 
-Gemba Walks können in der Softwareentwicklung als Code-Reviews oder Pair-Programming-Sessions interpretiert werden:
+Gemba Walks können in der Softwareentwicklung als **Code-Reviews** oder **Pair-Programming-Sessions** interpretiert werden:
 
-- Führe regelmäßige Code-Reviews durch, um Probleme frühzeitig zu erkennen.
-- Nutze Pair-Programming, um voneinander zu lernen und Probleme gemeinsam zu lösen.
-- Projektleiter sollten regelmäßig mit Entwicklern zusammenarbeiten, um Herausforderungen direkt zu erleben.
+➡️ Führe regelmäßige Code-Reviews durch, um Probleme frühzeitig zu erkennen. <br>
+➡️ Nutze Pair-Programming, um voneinander zu lernen und Probleme gemeinsam zu lösen. <br>
+➡️ Projektleiter sollten regelmäßig mit Entwicklern zusammenarbeiten, um Herausforderungen direkt zu erleben. <br>
+
+---
 
 ### Kanban in der Softwareentwicklung
 
 In der Softwareentwicklung setzen wir Kanban durch GitHub Issues um:
 
-- Nutze Boards in GitHub, um den Workflow zu visualisieren.
-- Begrenze die Anzahl der gleichzeitig bearbeiteten Issues (Work in Progress).
-- Aktualisiere den Status von Issues regelmäßig, um den Fortschritt transparent zu machen.
-- Nutze Labels und Meilensteine, um Prioritäten und Zeitpläne zu verdeutlichen.
+➡️ Nutze **Boards** in GitHub, um den Workflow zu visualisieren. <br>
+➡️ Begrenze die **Anzahl** der gleichzeitig bearbeiteten Issues (**Work in Progress**). <br>
+➡️ **Aktualisiere** den Status von Issues regelmäßig, um den Fortschritt transparent zu machen. <br>
+➡️ Nutze **[Labels](/docs/04-tools/01-github/04-issues/02-labels/README.md) und [Meilensteine](/docs/04-tools/01-github/04-issues/05-milestones/README.md)**, um Prioritäten und Zeitpläne zu verdeutlichen. <br>
+
+---
 
 ## Das NADOOIT System
 
-Unser NADOOIT System basiert auf bewährten Produktionsoptimierungsverfahren des Maschinenbaus wie REFA, Six Sigma und Lean. Es zeichnet sich durch eine einzigartige Produktivitätsgarantie aus[2]:
+Unser NADOOIT System basiert auf bewährten **Produktionsoptimierungsverfahren** des Maschinenbaus wie REFA, Six Sigma und Lean. Es zeichnet sich durch eine einzigartige **Produktivitätsgarantie** aus[2]:
 
-- Kunden zahlen nur für gemessene Verbesserungen in Geschäftsprozessen.
-- Wir erfassen, dokumentieren und automatisieren Geschäftsprozesse.
-- Einsatz modernster Technologien, einschließlich KI.
-- Höchste IT-Sicherheitsstandards.
+✅ Kunden zahlen nur für gemessene Verbesserungen in Geschäftsprozessen. <br>
+✅ Wir erfassen, dokumentieren und automatisieren Geschäftsprozesse. <br>
+✅ Einsatz modernster Technologien, einschließlich KI. <br>
+✅ Höchste IT-Sicherheitsstandards. <br>
+
+---
 
 ## Unsere Unternehmensphilosophie
 
 Bei Christoph Backhaus IT streben wir danach, ein "enkelfähiges" Software-Unternehmen aufzubauen. Das bedeutet:
 
-- Work-Life-Balance: Mitarbeiter sollen Zeit für Familie haben.
-- Partnerschaftliches Geschäftsmodell: Gemeinsam erreichen wir mehr.
-- Vertrauensbasis als Kernstück des Unternehmertums.
+➡️ **Work-Life-Balance**: Mitarbeiter sollen Zeit für Familie haben. <br>
+➡️ **Partnerschaftliches Geschäftsmodell**: Gemeinsam erreichen wir mehr. <br>
+➡️ **Vertrauensbasis** als Kernstück des Unternehmertums. <br>
+
+---
 
 ## Kommunikation und Transparenz
 
-Offene Kommunikation ist uns wichtig. Wir ermutigen Sie:
+Offene Kommunikation ist uns wichtig. Wir ermutigen dich dazu:
 
-- Verbesserungsvorschläge jederzeit einzureichen.
-- An offenen Dialogen teilzunehmen.
-- Fragen zu stellen und Ziele zu diskutieren.
+➡️ Verbesserungsvorschläge jederzeit einzureichen. <br>
+➡️ An offenen Dialogen teilzunehmen. <br>
+➡️ Fragen zu stellen und Ziele zu diskutieren. <br>
+
+---
 
 ## Fazit
 
-Unsere KAIZEN-basierte Kultur fördert kontinuierliche Verbesserung, Qualität und Innovation. Wenn etwas unklar ist oder nicht optimal funktioniert, ist dies ein Hinweis auf mangelnde Standardisierung. Es liegt an jedem von uns, dies zu kommunizieren und zu verbessern[5].
+Unsere KAIZEN-basierte Kultur fördert **kontinuierliche Verbesserung**, **Qualität** und **Innovation**. Wenn etwas unklar ist oder nicht optimal funktioniert, ist dies ein Hinweis auf **mangelnde Standardisierung**. Es liegt an jedem von uns, dies zu kommunizieren und zu verbessern[5].
 
-Die konsequente Anwendung von KAIZEN-Prinzipien in der Softwareentwicklung führt zu einer Kultur der kontinuierlichen Verbesserung, bei der Fehlerfreiheit die oberste Priorität ist. Methodische Prozesssauberkeit ist entscheidend für den Erfolg aller Beteiligten.
+Die konsequente Anwendung von KAIZEN-Prinzipien in der Softwareentwicklung führt zu einer Kultur der kontinuierlichen Verbesserung, bei der **Fehlerfreiheit die oberste Priorität** ist. **Methodische Prozesssauberkeit** ist entscheidend für den Erfolg aller Beteiligten.
 
 Solltest du nach dem Lesen dieses Wikis Unklarheiten oder Fragen zu einem der genannten Punkte oder Methoden haben, zögere bitte nicht, dies anzusprechen. Jede Unklarheit ist eine Gelegenheit zur Verbesserung unserer Prozesse und unserer Kommunikation. Dies ist ein wesentlicher Teil unserer Unternehmenskultur und ein wichtiger Schritt in deinem Onboarding-Prozess bei Christoph Backhaus IT.
 
-Citations:
-[1] https://www.studysmarter.de/studium/bwl/unternehmensfuehrung-studium/kaizen/
-[2] https://de.linkedin.com/in/christoph-backhaus
-[3] https://it-nerd24.de/tech-blog/kaizen-prozessoptimierung-und-qualitaetsmanagement-2024
-[4] https://nodapo.de
-[5] https://www.lucidchart.com/blog/de/kaizen-methode
-[6] https://ite-si.de/kompetenzen/individuelle-softwareentwicklung/
+#
+
+**Quellen / Zitate**
+
+[1] https://www.studysmarter.de/studium/bwl/unternehmensfuehrung-studium/kaizen/ <br>
+[2] https://de.linkedin.com/in/christoph-backhaus <br>
+[3] https://it-nerd24.de/tech-blog/kaizen-prozessoptimierung-und-qualitaetsmanagement-2024 <br>
+[4] https://nodapo.de <br>
+[5] https://www.lucidchart.com/blog/de/kaizen-methode <br>
+[6] https://ite-si.de/kompetenzen/individuelle-softwareentwicklung/ <br>
+
+---
+
+<p align="center">
+<a href="/docs/01-organisation/08-firmenphilosophie/02-feedback-kultur/README.md"><strong>Zurück</strong></a> | <a href="/docs/02-arbeiten_bei_nadoo/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/08-firmenphilosophie/README.md
+++ b/docs/01-organisation/08-firmenphilosophie/README.md
@@ -1,5 +1,26 @@
-# Umgang und Kultur bei NADOO-IT - Unsere Firmenphilosophien
+# <p align="center">Umgang und Kultur bei NADOO-IT - Unsere Firmenphilosophien</p>
 
-<!-- Einleitungstext und ggf. Auflisten von Kapiteln
+<p align="center">
+<a href="#dieser-abschnitt-beinhaltet-folgende-kapitel">zur Kapitelübersicht</a>
+</p>
 
-Keywords: Miteinander und Umgangston, Kulturen (Feedback) und Best-Practices (KAIZEN), Grundprinzipien... --> 
+---
+<!-- zu ergänzen: kurzer Einleitungstext 
+
+Keywords: Miteinander und Umgangston, Kulturen (Feedback) und Best-Practices (KAIZEN), Grundprinzipien... 
+
+"Abkürzung" zur Kapitel-Übersicht ggf. wieder entfernen--> 
+
+### Dieser Themen-Abschnitt beinhaltet folgende Kapitel:
+
+#
+
+🔹 [**Verhaltensregeln bei Christoph Backhaus / NADOO-IT**](/docs/01-organisation/08-firmenphilosophie/01-verhaltensregeln/README.md) </br>
+🔹 [**Feedback-Kultur bei Christoph Backhaus IT**](/docs/01-organisation/08-firmenphilosophie/02-feedback-kultur/README.md) </br>
+🔹 [**KAIZEN bei Christoph Backhaus IT: Eine Kultur der kontinuierlichen Verbesserung**](/docs/01-organisation/08-firmenphilosophie/03-kaizen/README.md) </br>
+
+---
+
+<p align="center">
+<a href="/docs/01-organisation/07-datenschutz/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/08-firmenphilosophie/01-verhaltensregeln/README.md"><strong>Weiter</strong></a>
+</p>

--- a/docs/01-organisation/08-firmenphilosophie/README.md
+++ b/docs/01-organisation/08-firmenphilosophie/README.md
@@ -1,7 +1,7 @@
 # <p align="center">Umgang und Kultur bei NADOO-IT - Unsere Firmenphilosophien</p>
 
 <p align="center">
-<a href="#dieser-abschnitt-beinhaltet-folgende-kapitel">zur Kapitelübersicht</a>
+<a href="#dieser-themen-abschnitt-beinhaltet-folgende-kapitel">zur Kapitelübersicht</a>
 </p>
 
 ---

--- a/docs/01-organisation/README.md
+++ b/docs/01-organisation/README.md
@@ -1,7 +1,7 @@
-# Organisation & Rahmenbedingungen
+# <p align="center">Organisation & Rahmenbedingungen</p>
 
 <p align="center">
-<a href="#dieses-wiki-thema-beinhaltet-folgende-abschnitte">zu den Themen-Abschnitten</a>
+<a href="#dieser-wiki-themenbereich-beinhaltet-folgende-themen-abschnitte">zu den Themen-Abschnitten</a>
 </p>
 
 <!-- ggf. noch ergänzen: Einleitungstext zum Abschnitt -->

--- a/docs/01-organisation/README.md
+++ b/docs/01-organisation/README.md
@@ -1,3 +1,24 @@
-# Organisation & Rahmenbedingungen 
+# Organisation & Rahmenbedingungen
 
-<!-- kurzer Einleitungstext zum Abschnitt und ggf. Auflisten von Kapiteln--> 
+<p align="center">
+<a href="#dieses-wiki-thema-beinhaltet-folgende-abschnitte">zu den Themen-Abschnitten</a>
+</p>
+
+<!-- ggf. noch ergänzen: Einleitungstext zum Abschnitt -->
+
+### Dieser Wiki-Themenbereich beinhaltet folgende Themen-Abschnitte:
+
+🔹 [**Zeiterfassung / Einstempeln**](/docs/01-organisation/01-zeiterfassung/README.md) </br>
+🔹 [**Zeit- und Ausbildungsnachweise**](/docs/01-organisation/02-zeit_und_ausbildungsnachweise/README.md) </br>
+🔹 [**Arbeits- und Pausenzeiten**](/docs/01-organisation/03-arbeits_und_pausenzeiten/README.md)</br>
+🔹 [**Urlaub**](/docs/01-organisation/04-urlaub/README.md) </br>
+🔹 [**Krankmeldungen**](/docs/01-organisation/05-krankmeldungen/README.md) </br>
+🔹 [**Mutterschutz & Elternzeit**](/docs/01-organisation/06-mutterschutz_und_elternzeit/README.md) </br>
+🔹 [**Umgang mit Unternehmensdaten**](/docs/01-organisation/07-datenschutz/README.md) </br>
+🔹 [**Verhalten und Kultur bei Christoph Backhaus IT - Unsere Firmenphilosophien**](/docs/01-organisation/08-firmenphilosophie/README.md) </br>
+
+---
+
+<p align="center">
+<a href="/docs/00-willkommen/README.md"><strong>Zurück</strong></a> | <a href="/docs/01-organisation/01-zeiterfassung/README.md"><strong>Weiter</strong></a>
+</p>


### PR DESCRIPTION
**Änderungen in den Wiki-Themenbereichen "Einstieg" und "Organisation":**

- Navigationsbar in allen docs hinzugefügt/korrigiert
- relevante docs um Übersichten der Abschnitte/Kapitel ergänzt
- veraltete Links/Verweise innerhalb der docs aktualisiert
- Texte um Anker-Links zu bestimmten Stellen in docs erweitert
- wahlweise stilistische Anpassungen über alle bearbeiteten docs hinweg

**Feedback-Anfrage**: 

habe mal ein bisschen HTML integriert, um **Titel und Navigationsbar** zu **zentrieren**. 

auch der **Shortcut/Ankerlink ("zur Kapitel-/Abschnittsübersicht")** war ne neue Idee, die ich spontan mit reingebracht hab. an sich gefällt mir das Konzept. an der ein oder anderen Stelle macht's, denke ich, auch Sinn. andererseits sind die meisten Einleitungstexte eher kurz (oder es gibt halt keinen :D) und dann wirkt das "springe zu" irgendwo überflüssig. 

gleichzeitig hatte ich die Überlegung, dass gerade, wenn man über die **mobile Ansicht** durchs Wiki surft - wo dann alles etwas komprimierter ist - ist das schon ein nettes Feature. würd's dann aber schon **einheitlich** überall einbinden, wo es min. 2 Unterordner gibt - grundsätzlich können sich Themenbereiche und- abschnitte ja auch jederzeit durch weitere Kapitel vergrößern.

**Was meint ihr - yay or nay? :D** 