### PR TITLE
Fix link path in examples README

### DIFF
--- a/docs/01-organisation/02-zeit_und_ausbildungsnachweise/01-beispiele/README.md
+++ b/docs/01-organisation/02-zeit_und_ausbildungsnachweise/01-beispiele/README.md
@@ -223,5 +223,5 @@ MitarbeiterID_MESSEBESUCH_YYYY_MM_TT / 13_MESSEBESUCH_2025_09_18
 ---
 <p align="center">
 <a href="/docs/01-organisation/02-zeit_und_ausbildungsnachweise/README.md"><strong>Zurück</strong></a> | 
-<a  href="\docs\01-organisation\02-zeit_und_ausbildungsnachweise\02-dateibenennung\README.md"><strong>Weiter</strong></a>
+<a  href=" /docs/01-organisation/02-zeit_und_ausbildungsnachweise/02-dateibenennung/README.md"><strong>Weiter</strong></a>
 </p>


### PR DESCRIPTION
Corrected the 'Weiter' link to use the proper relative path format in the README for example training records.