### PR TITLE
Formatierung des Textes angepasst und einheitlich gestaltet

### DIFF
--- a/docs/01-organisation/04-urlaub/README.md
+++ b/docs/01-organisation/04-urlaub/README.md
@@ -15,8 +15,9 @@ Wenn du bei **Christoph Backhaus IT** im Zuge einer **Umschulung** als **Praktik
 **2.** Schicke dafür eine kurze E-Mail an [**christoph.backhaus@nadooit.de**](mailto:christoph.backhaus@nadooit.de). Formuliere den **Betreff** dabei basierend auf dem folgenden Muster:
 <br> 
 
-MitarbeiterID_URLAUBSANTRAG_START_YYYY_MM_TT_ENDE_YYYY_MM_TT
-13_URLAUBSANTRAG_START_2025_09_19_ENDE_2025_10_10
+**Betreff:**    MitarbeiterID_URLAUBSANTRAG_START_YYYY_MM_TT_ENDE_YYYY_MM_TT
+
+**Beispiel:**   13_URLAUBSANTRAG_START_2025_09_19_ENDE_2025_10_10
 
 ## Alle, die die Schule (Umschulung) besuchen müssen
 
@@ -25,7 +26,9 @@ Wenn ihr es noch nicht wisst und später erfahrt, gebt bitte ein paar Tage vor B
 🚩 Dies ist eine Pflichtregel, das heißt, ihr müsst dies unbedingt einhalten.
 
 Schicke eine E-Mail an [**christoph.backhaus@nadooit.de**](mailto:christoph.backhaus@nadooit.de).
-**Betreff:**  MitarbeiterID_SCHULE_START_YYYY_MM_TT_ENDE_YYYY_MM_TT 
+
+**Betreff:**   MitarbeiterID_SCHULE_START_YYYY_MM_TT_ENDE_YYYY_MM_TT 
+
 **Beispiel:**  13_SCHULE_START_2025_09_19_ENDE_2025_11_03 
 
 ---


### PR DESCRIPTION
In dem oberen Betreff und dem Beispiel wurden die Wörter Betreff und Beispiel wie im unteren Absatz hinzugefügt, damit es einheitlich aussieht. Ebenso wurden jeweils bei beiden Absätzen ein Zeilenumbruch hinzugefügt, damit beides nicht in der selben Zeile steht.