### PR TITLE
Verlinkungen aktualisiert

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ Unterschiedliche Kulturen und Sprachen werden hier bei NADOO-IT gelebt und gesch
 
   &emsp;📄 [Kapitelübersicht](docs/01-organisation/03-zeit_und_ausbildungsnachweise/README.md)
 
-  &nbsp;&nbsp;🔹 [Beispiele für Ausbildungs- und Zeitnachweise](docs/01-organisation/02-zeit_und_ausbildungsnachweise/01-beispiele/README.md) <br>
-  &nbsp;&nbsp;🔹 [Dateibenennungsrichtlinien](docs/01-organisation/02-zeit_und_ausbildungsnachweise/02-dateibenennung/README.md) <br>
-  &nbsp;&nbsp;🔹 [Überprüfung der Dateinamen](/docs/01-organisation/02-zeit_und_ausbildungsnachweise/03-ueberpruefung/README.md) <br>
+  &nbsp;&nbsp;🔹 [Beispiele für Ausbildungs- und Zeitnachweise](docs/01-organisation/03-zeit_und_ausbildungsnachweise/01-beispiele/README.md) <br>
+  &nbsp;&nbsp;🔹 [Dateibenennungsrichtlinien](docs/01-organisation/03-zeit_und_ausbildungsnachweise/02-dateibenennung/README.md) <br>
+  &nbsp;&nbsp;🔹 [Überprüfung der Dateinamen](/docs/01-organisation/03-zeit_und_ausbildungsnachweise/03-ueberpruefung/README.md) <br>
 
 </details>
 

--- a/docs/04-tools/README.md
+++ b/docs/04-tools/README.md
@@ -13,9 +13,10 @@ Ob für die **Verwaltung** von Daten und Prozessen, die **Dokumentation** von Wi
 🢒  [**Versionsverwaltung mit GitHub**](/docs/04-tools/01-github/README.md) <br>
 🢒  [**Integrierte Entwicklungsumgebung (IDE) Visual Studio Code**](/docs/04-tools/02-vscode/README.md) <br>
 🢒  [**Integrierte Entwicklungsumgebung (IDE) für Java: IntelliJ IDEA**](/docs/04-tools/03-intellij/README.md) <br>
-🢒  [**Das Terminal — die Grundlagen**](/docs/04-tools/04-terminal/README.md) <br>
-🢒  [**Das NADOO-Launchpad — was es kann und wie es funktioniert**](/docs/04-tools/05-launchpad/README.md) <br>
-🢒  [**Künstliche Intelligenz (KI)**](/docs/04-tools/06-ki/README.md) <br>
+🢒  [**Integrierte Entwicklungsumgebung (IDE) Windsurf**](/docs/04-tools/04-windsurf/README.md) <br>
+🢒  [**Das Terminal — die Grundlagen**](/docs/04-tools/05-terminal/README.md) <br>
+🢒  [**Das NADOO-Launchpad — was es kann und wie es funktioniert**](/docs/04-tools/06-launchpad/README.md) <br>
+🢒  [**Künstliche Intelligenz (KI)**](/docs/04-tools/07-ki/README.md) <br>
 
 ---
 


### PR DESCRIPTION
Die fehlerhaften Verlinkungen in der README von 00-Wilkommen unter dem Punkt 03 Zeit- und Ausbildungsnachweise wurden korrigiert Die README von 04-Tools wurde um den Themenpunkt Windsurf erweitert und alle nachfolgenden Verlinkungen aktualisiert